### PR TITLE
Add caido-ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 - [GraphQL Schema](https://github.com/caido/caido/blob/main/plugin/schema.graphql) - The GraphQL schema of Caido
 - [BigMom](https://github.com/Dyrandy/bigmom) - Golang Caido GraphQL Client Tool
 - [caido-python](https://github.com/thiezn/caido-python) - Python client library to interact with Caido
+- [caido-ruby](https://github.com/caineers/caido-ruby) - The caido-ruby library simplifies using Caido's API in Ruby applications.
 
 ## Workflows
 - [Official Store](https://github.com/caido/workflows) - Workflows shared by the community.


### PR DESCRIPTION
Hi,
First of all, thank you so much for creating such an excellent tool like Caido :)

This PR adds caido-ruby to the Caido Awesome list. caido-ruby is a Ruby library that simplifies querying Caido's GraphQL API, making it easier for Ruby applications to retrieve various information.